### PR TITLE
Show better force push diff

### DIFF
--- a/disgit.js
+++ b/disgit.js
@@ -254,7 +254,7 @@ function buildPush(json) {
             "embeds": [
                 {
                     "title": "[" + repository["full_name"] + "] Branch " + branch +  " was force-pushed to `" + shortCommit(after) + "`",
-                    "url": compare,
+                    "url": compare.replace("...", ".."),
                     "author": {
                         "name": sender["login"],
                         "url": sender["html_url"],


### PR DESCRIPTION
By default, GitHub will use `...` for diff here. Using `...` for the comparison will only show the new commit (see image for a better explanation).

Example (`...`): https://github.com/robertcoopercode/proof-of-concept/compare/5c9a40314c69179021150069eb565fd9095abc3b...12e73d1d9b815e11b39bb89b58470cb616f0ad44
Example (`..`): https://github.com/robertcoopercode/proof-of-concept/compare/5c9a40314c69179021150069eb565fd9095abc3b..12e73d1d9b815e11b39bb89b58470cb616f0ad44

The second is more likely what you'd want for a force push.

You could also use regex for this to be more foolproof, but I figured just a simple replacement would be sufficient as you can't have a repo, commit hash, or account/org name containing `...`.

![diff .. vs ...](http://tpscash.github.io/images/posts/git/git-diff-help.png)